### PR TITLE
examples/dashboard: make text bigger and configurable

### DIFF
--- a/examples/dashboard.html
+++ b/examples/dashboard.html
@@ -28,18 +28,23 @@
   summary {
     text-align: center;
     padding: 20px 0;
+    font-size: 30px;
   }
 
   #tx-count,
   #stats-title {
     text-align: center;
   }
+
+  .c3-chart-arcs-title {
+    font-size: 30px;
+  }
 </style>
 
 <div class="container">
   <div id="chart-ledger"></div>
   <details open>
-    <summary>Signers</summary>
+    <summary>Account Signers</summary>
     <div class="chart-container">
       <div class="chart-cell-1" id="chart-signers-1"></div>
       <div class="chart-cell-2" id="chart-signers-2"></div>
@@ -61,16 +66,20 @@
 </div>
 
 <script>
+  const params = Object.fromEntries(new URLSearchParams(window.location.search).entries());
+  params.localName ||= "Local";
+  params.remoteName ||= "Remote";
+
   window.addEventListener('load', (event) => {
     const horizonUrl = "http://192.168.64.2:8000";
     const agentUrl = "http://localhost:9000";
-    chartLedger('#chart-ledger', horizonUrl);
-    chartAccountSigners('#chart-signers-1', agentUrl, horizonUrl, true);
-    chartAccountSigners('#chart-signers-2', agentUrl, horizonUrl, false);
-    chartAccountBalances('#chart-account-balances', agentUrl, horizonUrl);
-    chartChannelBalance('#chart-channel-balance', agentUrl);
-    txCount('#tx-count', agentUrl);
-    stats('#stats', agentUrl);
+    chartLedger(params, '#chart-ledger', horizonUrl);
+    chartAccountSigners(params, '#chart-signers-1', agentUrl, horizonUrl, true);
+    chartAccountSigners(params, '#chart-signers-2', agentUrl, horizonUrl, false);
+    chartAccountBalances(params, '#chart-account-balances', agentUrl, horizonUrl);
+    chartChannelBalance(params, '#chart-channel-balance', agentUrl);
+    txCount(params, '#tx-count', agentUrl);
+    stats(params, '#stats', agentUrl);
   });
 </script>
 
@@ -79,7 +88,7 @@
   const color1Light = '#f4a267';
   const color2 = '#f08536';
   const color2Light = '#84afd7';
-  function chartLedger(bindto, horizonUrl) {
+  function chartLedger(params, bindto, horizonUrl) {
     const chart = c3.generate({
       bindto: bindto,
       data: {
@@ -108,12 +117,12 @@
     setInterval(chartUpdate, 1000);
   }
 
-  function chartAccountSigners(bindto, agentUrl, horizonUrl, local) {
+  function chartAccountSigners(params, bindto, agentUrl, horizonUrl, local) {
     const chart = c3.generate({
       bindto: bindto,
       data: { type: 'donut', labels: true, columns: [], order: null },
       donut: {
-        title: `${local ? 'Local' : 'Remote'} Account Signers`,
+        title: `${local ? params.localName : params.remoteName}`,
       },
       legend: {
         show: false
@@ -153,12 +162,12 @@
     setInterval(chartUpdate, 1000);
   }
 
-  function chartAccountBalances(bindto, agentUrl, horizonUrl) {
+  function chartAccountBalances(params, bindto, agentUrl, horizonUrl) {
     const chart = c3.generate({
       bindto: bindto,
       data: { type: 'donut', labels: true, columns: [], order: null },
       donut: {
-        title: `Balances on Network`,
+        title: `Network`,
         label: {
           format: function (value, ratio, id) {
             return d3.format('$,')(value);
@@ -206,12 +215,12 @@
     setInterval(chartUpdate, 100);
   }
 
-  function chartChannelBalance(bindto, agentUrl) {
+  function chartChannelBalance(params, bindto, agentUrl) {
     const chart = c3.generate({
       bindto: bindto,
       data: { type: 'donut', labels: true, columns: [], order: null, },
       donut: {
-        title: `Balances in Channel`,
+        title: `Channel`,
         label: {
           format: function (value, ratio, id) {
             return d3.format('$,')(value / 10000000);
@@ -300,7 +309,7 @@
     setInterval(chartUpdate, 100);
   }
 
-  function txCount(bindto, agentUrl) {
+  function txCount(params, bindto, agentUrl) {
     const chartUpdate = async () => {
       const resp = await fetch(`${agentUrl}`)
       const json = await resp.json();
@@ -312,7 +321,7 @@
     setInterval(chartUpdate, 100);
   }
 
-  function stats(bindto, agentUrl) {
+  function stats(params, bindto, agentUrl) {
     const chart = c3.generate({
       bindto: bindto,
       data: { type: 'gauge', labels: true, columns: [] },


### PR DESCRIPTION
### What
Make the text bigger on the dashboard, and make configurable the names used for the elements that are associated with a local and remote participant.

### Why
The dashboard was primarily created to make it easier to demo low level experiments that don't otherwise have much of a UI. During demos bigger text is more legible. Also, typically there's two of us performing the demo and by making the names of the UI elements explicit to which person the account relates it makes it easier to understand the demo.

### Example

https://user-images.githubusercontent.com/351529/138175001-66575d1f-72ed-4cb4-bb4a-b5e2f0e12bab.mp4

RFR @acharb 
CC @accordeiro 