### PR TITLE
examples/console: use terminology agreement for each agreement

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -144,10 +144,18 @@ func run() error {
 
 			case agentpkg.PaymentReceivedEvent:
 				closeAgreements = append(closeAgreements, e.CloseAgreement)
-				stats.AddPaymentsReceived(1)
+				// As this example uses the buffered agent, each
+				// PaymentReceivedEvent, is a new CloseAgreement containing many
+				// buffered payments. The BufferedPaymentsReceivedEvent will
+				// also be triggered and will contain the buffered payments.
+				stats.AddAgreementsReceived(1)
 			case agentpkg.PaymentSentEvent:
 				closeAgreements = append(closeAgreements, e.CloseAgreement)
-				stats.AddPaymentsSent(1)
+				// As this example uses the buffered agent, each
+				// PaymentSentEvent, is a new CloseAgreement containing many
+				// buffered payments. The BufferedPaymentsSentEvent will also be
+				// triggered and will contain the buffered payments.
+				stats.AddAgreementsSent(1)
 
 			case bufferedagent.BufferedPaymentsReceivedEvent:
 				stats.AddBufferedPaymentsReceived(len(e.Payments))

--- a/examples/console/stats.go
+++ b/examples/console/stats.go
@@ -13,8 +13,8 @@ type stats struct {
 	mu                       sync.RWMutex
 	timeStart                time.Time
 	timeFinish               time.Time
-	paymentsSent             int64
-	paymentsReceived         int64
+	agreementsSent           int64
+	agreementsReceived       int64
 	bufferedPaymentsSent     int64
 	bufferedPaymentsReceived int64
 }
@@ -24,8 +24,8 @@ func (s *stats) Reset() {
 	defer s.mu.Unlock()
 	s.timeStart = time.Time{}
 	s.timeFinish = time.Time{}
-	s.paymentsSent = 0
-	s.paymentsReceived = 0
+	s.agreementsSent = 0
+	s.agreementsReceived = 0
 	s.bufferedPaymentsSent = 0
 	s.bufferedPaymentsReceived = 0
 }
@@ -34,8 +34,8 @@ func (s *stats) Clone() *stats {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return &stats{
-		paymentsSent:             s.paymentsSent,
-		paymentsReceived:         s.paymentsReceived,
+		agreementsSent:           s.agreementsSent,
+		agreementsReceived:       s.agreementsReceived,
 		bufferedPaymentsSent:     s.bufferedPaymentsSent,
 		bufferedPaymentsReceived: s.bufferedPaymentsReceived,
 	}
@@ -45,8 +45,8 @@ func (s *stats) Merge(o *stats) *stats {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return &stats{
-		paymentsSent:             s.paymentsSent + o.paymentsSent,
-		paymentsReceived:         s.paymentsReceived + o.paymentsReceived,
+		agreementsSent:           s.agreementsSent + o.agreementsSent,
+		agreementsReceived:       s.agreementsReceived + o.agreementsReceived,
 		bufferedPaymentsSent:     s.bufferedPaymentsSent + o.bufferedPaymentsSent,
 		bufferedPaymentsReceived: s.bufferedPaymentsReceived + o.bufferedPaymentsReceived,
 	}
@@ -70,16 +70,16 @@ func (s *stats) MarkFinish() {
 	s.timeFinish = time.Now()
 }
 
-func (s *stats) AddPaymentsSent(delta int) {
+func (s *stats) AddAgreementsSent(delta int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.paymentsSent += int64(delta)
+	s.agreementsSent += int64(delta)
 }
 
-func (s *stats) AddPaymentsReceived(delta int) {
+func (s *stats) AddAgreementsReceived(delta int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.paymentsReceived += int64(delta)
+	s.agreementsReceived += int64(delta)
 }
 
 func (s *stats) AddBufferedPaymentsSent(delta int) {
@@ -94,17 +94,17 @@ func (s *stats) AddBufferedPaymentsReceived(delta int) {
 	s.bufferedPaymentsReceived += int64(delta)
 }
 
-func (s *stats) PaymentsPerSecond() float64 {
+func (s *stats) AgreementsPerSecond() float64 {
 	timeFinish := s.timeFinish
 	if timeFinish.IsZero() {
 		timeFinish = time.Now()
 	}
 	duration := s.timeFinish.Sub(s.timeStart)
-	pps := float64(s.paymentsSent+s.paymentsReceived) / duration.Seconds()
-	if math.IsNaN(pps) || math.IsInf(pps, 0) {
-		pps = 0
+	rate := float64(s.agreementsSent+s.agreementsReceived) / duration.Seconds()
+	if math.IsNaN(rate) || math.IsInf(rate, 0) {
+		rate = 0
 	}
-	return pps
+	return rate
 }
 
 func (s *stats) BufferedPaymentsPerSecond() float64 {
@@ -113,11 +113,11 @@ func (s *stats) BufferedPaymentsPerSecond() float64 {
 		timeFinish = time.Now()
 	}
 	duration := timeFinish.Sub(s.timeStart)
-	bpps := float64(s.bufferedPaymentsSent+s.bufferedPaymentsReceived) / duration.Seconds()
-	if math.IsNaN(bpps) || math.IsInf(bpps, 0) {
-		bpps = 0
+	rate := float64(s.bufferedPaymentsSent+s.bufferedPaymentsReceived) / duration.Seconds()
+	if math.IsNaN(rate) || math.IsInf(rate, 0) {
+		rate = 0
 	}
-	return bpps
+	return rate
 }
 
 func (s *stats) Summary() string {
@@ -130,9 +130,9 @@ func (s *stats) Summary() string {
 	}
 	duration := timeFinish.Sub(s.timeStart)
 	fmt.Fprintf(&sb, "time spent: %v\n", duration)
-	fmt.Fprintf(&sb, "payments sent: %d\n", s.paymentsSent)
-	fmt.Fprintf(&sb, "payments received: %d\n", s.paymentsReceived)
-	fmt.Fprintf(&sb, "payments tps: %.3f\n", s.PaymentsPerSecond())
+	fmt.Fprintf(&sb, "agreements sent: %d\n", s.agreementsSent)
+	fmt.Fprintf(&sb, "agreements received: %d\n", s.agreementsReceived)
+	fmt.Fprintf(&sb, "agreements tps: %.3f\n", s.AgreementsPerSecond())
 	fmt.Fprintf(&sb, "buffered payments sent: %d\n", s.bufferedPaymentsSent)
 	fmt.Fprintf(&sb, "buffered payments received: %d\n", s.bufferedPaymentsReceived)
 	fmt.Fprintf(&sb, "buffered payments tps: %.3f\n", s.BufferedPaymentsPerSecond())
@@ -143,16 +143,16 @@ func (s *stats) MarshalJSON() ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	v := struct {
-		PaymentsSent              int64
-		PaymentsReceived          int64
-		PaymentsPerSecond         int64
+		AgreementsSent            int64
+		AgreementsReceived        int64
+		AgreementsPerSecond       int64
 		BufferedPaymentsSent      int64
 		BufferedPaymentsReceived  int64
 		BufferedPaymentsPerSecond int64
 	}{
-		PaymentsSent:              s.paymentsSent,
-		PaymentsReceived:          s.paymentsReceived,
-		PaymentsPerSecond:         int64(s.PaymentsPerSecond()),
+		AgreementsSent:            s.agreementsSent,
+		AgreementsReceived:        s.agreementsReceived,
+		AgreementsPerSecond:       int64(s.AgreementsPerSecond()),
 		BufferedPaymentsSent:      s.bufferedPaymentsSent,
 		BufferedPaymentsReceived:  s.bufferedPaymentsReceived,
 		BufferedPaymentsPerSecond: int64(s.BufferedPaymentsPerSecond()),


### PR DESCRIPTION
### What
Use "agreement" to refer to each off-network payment that contains the buffered payments.

### Why
It is confusing talking about two types of payments, the aggregate payment and the buffered payments. It's simpler and easier to understand if in the buffered payments demo we describe the channel payment that is part of the close agreement as an agreement. In the dashboard we use with the demo it is already described as an agreement rather than a payment. So this makes the code more consistent with the UI.