### PR TITLE
examples/console: replace random amounts with evenly distributed amounts

### DIFF
--- a/examples/console/main.go
+++ b/examples/console/main.go
@@ -414,7 +414,9 @@ func prompt(agent *bufferedagent.Agent, stats *stats, submitter agentpkg.Submitt
 		for i := 0; i < x; i++ {
 			memo := "tx-" + strconv.Itoa(i)
 			for {
-				amt := int64(i)%amt + 1
+				// Make each payment have an amount that is distributed between
+				// the minimum amount, 0.0000001 and the amount given.
+				amt := int64(i+1) * amt / int64(x)
 				_, err = agent.PaymentWithMemo(amt, memo)
 				if err != nil {
 					continue


### PR DESCRIPTION
### What
Replace random amounts used in benchmarks with evenly distributed amounts.

### Why
It turns out calling random repeatedly when generating payments is reasonably expensive and is slowing down the payment sending. The goal with using random amounts is to simulate somewhat realistic payments so that things like message size is more realistic and message compression doesn't work unnaturally well. Using a even distribution by modding the max amount with the current payment number should achieve the same thing without the expensive random call.