### PR TITLE
Fix broken link in readme

### DIFF
--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           version: v1.45.2
           working-directory: examples/console
-skip-go-installation: true
+          skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -18,10 +18,11 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          version: v1.53.3
+          version: v1.45.2
           working-directory: examples/console
+skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -18,11 +18,10 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
+        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299
         with:
-          version: v1.45.2
+          version: v1.53.3
           working-directory: examples/console
-          skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          version: v1.45.2
+          version: v1.56.2
           working-directory: examples/console
           skip-go-installation: true
 

--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -2,13 +2,9 @@ name: 'Examples: Console'
 
 on:
   push:
-    paths-ignore:
-      - 'README.md'
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - 'README.md'
 
 jobs:
 

--- a/.github/workflows/examples-console.yml
+++ b/.github/workflows/examples-console.yml
@@ -2,9 +2,13 @@ name: 'Examples: Console'
 
 on:
   push:
+    paths-ignore:
+      - 'README.md'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'README.md'
 
 jobs:
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,9 +18,9 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2dcd82f331c9e834f283075b23ef289435be9354
+        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299
         with:
-          version: v1.45.2
+          version: v1.53.3
           working-directory: sdk
           skip-go-installation: true
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
+        uses: golangci/golangci-lint-action@2dcd82f331c9e834f283075b23ef289435be9354
         with:
           version: v1.45.2
           working-directory: sdk

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          version: v1.45.2
+          version: v1.56.2
           working-directory: sdk
           skip-go-installation: true
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -2,13 +2,9 @@ name: SDK
 
 on:
   push:
-    paths-ignore:
-      - 'README.md'
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - 'README.md'
 
 jobs:
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Stellar Quickstart: Run"
-      run: docker run -d -p 8000:8000 --name stellar stellar/quickstart --standalone --enable-core-artificially-accelerate-time-for-testing
+      run: docker run -d -p 8000:8000 --name stellar stellar/quickstart --local
     - name: "Stellar Quickstart: Wait for Ready"
       run: while ! [ "$(curl -s --fail localhost:8000 | jq '.history_latest_ledger')" -gt 0 ]; do echo waiting; sleep 1; done
     - name: "Stellar Quickstart: Details"

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,10 +18,11 @@ jobs:
         with:
           go-version: 1
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
         with:
-          version: v1.53.3
+          version: v1.45.2
           working-directory: sdk
+skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -2,9 +2,13 @@ name: SDK
 
 on:
   push:
+    paths-ignore:
+      - 'README.md'
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - 'README.md'
 
 jobs:
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           version: v1.53.3
           working-directory: sdk
-          skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           version: v1.45.2
           working-directory: sdk
-skip-go-installation: true
+          skip-go-installation: true
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ More details in the [README](https://github.com/stellar/starlight/tree/main/exam
 
 ## Get involved
 
-- [Discord](https://discord.gg/xGWRjyNzQh)
+- [Discord](https://discord.gg/stellardev)
 - [Discussions](https://github.com/stellar/starlight/discussions)
 - [Demos](https://github.com/stellar/starlight/discussions/categories/demos)
 - [Getting Started](Getting%20Started.md)

--- a/examples/console/stats.go
+++ b/examples/console/stats.go
@@ -108,7 +108,7 @@ func (s *stats) AgreementsPerSecond() float64 {
 	if timeFinish.IsZero() {
 		timeFinish = time.Now()
 	}
-	duration := s.timeFinish.Sub(s.timeStart)
+	duration := timeFinish.Sub(s.timeStart)
 	rate := float64(s.agreementsSent+s.agreementsReceived) / duration.Seconds()
 	if math.IsNaN(rate) || math.IsInf(rate, 0) {
 		rate = 0

--- a/sdk/.golangci.yml
+++ b/sdk/.golangci.yml
@@ -3,8 +3,6 @@ linters:
   enable:
     - gofmt
     - gofumpt
-  disable:
-    - gocritic
 
 linters-settings:
   govet:

--- a/sdk/.golangci.yml
+++ b/sdk/.golangci.yml
@@ -3,6 +3,8 @@ linters:
   enable:
     - gofmt
     - gofumpt
+  disable:
+    - gocritic
 
 linters-settings:
   govet:

--- a/sdk/state/doc.go
+++ b/sdk/state/doc.go
@@ -18,16 +18,16 @@ The Open, Payment, and Close operations are broken up into three steps:
 - Finalize*: Called by the payer to finalize the agreement with the payees
 signatures.
 
-  +-----------+      +-----------+
-  |   Payer   |      |   Payee   |
-  +-----+-----+      +-----+-----+
-        |                  |
-     Propose               |
-        +----------------->+
-        |               Confirm
-        +<-----------------+
-    Finalize*              |
-        |                  |
+	+-----------+      +-----------+
+	|   Payer   |      |   Payee   |
+	+-----+-----+      +-----+-----+
+	      |                  |
+	   Propose               |
+	      +----------------->+
+	      |               Confirm
+	      +<-----------------+
+	  Finalize*              |
+	      |                  |
 
 * Note that the Open and Close processes do not have a Finalize operation, and the
 Confirm is used in its place at this time. A Finalize operation is likely to be


### PR DESCRIPTION
### What
Change the Discord link to point to the public Stellar Dev Discord.

### Why
The link in the readme looks like it is an expired link. There's no risk created by this, however we should fix it so the link is not broken and still leads to the Stellar Dev Discord. Since the Discord server is public now there's no need for an invite link link before.